### PR TITLE
Security headers + OG/meta fixes (review-gated)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,25 @@
       name="description"
       content="Critical History Map of Yale and New Haven sites shaped by colonial history, institutional power, and student and resident organizing."
     />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Critical History Map" />
+    <meta property="og:title" content="Critical History Map" />
+    <meta
+      property="og:description"
+      content="Critical History Map of Yale and New Haven sites shaped by colonial history, institutional power, and student and resident organizing."
+    />
+    <meta property="og:url" content="https://ycriticalhistory.org/" />
+    <meta property="og:image" content="https://ycriticalhistory.org/icons/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Critical History Map logo over a map of Yale and New Haven" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Critical History Map" />
+    <meta
+      name="twitter:description"
+      content="Critical History Map of Yale and New Haven sites shaped by colonial history, institutional power, and student and resident organizing."
+    />
+    <meta name="twitter:image" content="https://ycriticalhistory.org/icons/og-image.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png" />

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,10 @@ const BUILT_PUBLIC_DIR = resolve(import.meta.dir, "public");
 const SOURCE_PUBLIC_DIR = resolve(import.meta.dir, "..", "public");
 const PUBLIC_DIR = resolve(Bun.env.PUBLIC_DIR ?? (IS_BUILT_SERVER ? BUILT_PUBLIC_DIR : SOURCE_PUBLIC_DIR));
 
+const SECURITY_HEADERS: Readonly<Record<string, string>> = {
+  "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+};
+
 const CONTENT_TYPES: Readonly<Record<string, string>> = {
   ".css": "text/css; charset=utf-8",
   ".html": "text/html; charset=utf-8",
@@ -22,6 +26,10 @@ const CONTENT_TYPES: Readonly<Record<string, string>> = {
 };
 
 export async function handleRequest(request: Request): Promise<Response> {
+  return withSecurityHeaders(await routeRequest(request));
+}
+
+async function routeRequest(request: Request): Promise<Response> {
   const url = new URL(request.url);
 
   if (request.method !== "GET" && request.method !== "HEAD") {
@@ -62,6 +70,19 @@ if (import.meta.main) {
   });
 
   console.info(`listening on ${server.url}`);
+}
+
+function withSecurityHeaders(response: Response): Response {
+  const headers = new Headers(response.headers);
+  for (const [key, value] of Object.entries(SECURITY_HEADERS)) {
+    headers.set(key, value);
+  }
+
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
 }
 
 function json(body: unknown, headers: HeadersInit = {}, status = 200): Response {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -43,4 +43,13 @@ describe("server", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toContain("text/html");
   });
+
+  test("sets strict-transport-security on every response", async () => {
+    const paths = ["/healthz", "/api/config", "/api/locations", "/", "/privacy", "/does-not-exist.png"];
+
+    for (const path of paths) {
+      const response = await handleRequest(new Request(`http://localhost${path}`));
+      expect(response.headers.get("Strict-Transport-Security")).toBe("max-age=31536000; includeSubDomains");
+    }
+  });
 });

--- a/tools/lint.ts
+++ b/tools/lint.ts
@@ -8,7 +8,11 @@ const failures: string[] = [];
 await requireContains("Dockerfile", "dhi.io/bun", "Dockerfile must use Docker Hardened Bun images.");
 await requireContains("Dockerfile", "bun upgrade --canary", "Dockerfile must upgrade Bun to the latest canary.");
 await requireContains("public/index.html", 'rel="icon"', "The document must link a favicon.");
-await rejectContains("public/index.html", "https://", "The document should not load third-party scripts or styles.");
+await rejectPattern(
+  "public/index.html",
+  /<(?:script[^>]*\ssrc|link[^>]*\shref)="https?:\/\//,
+  "The document should not load third-party scripts or styles.",
+);
 await rejectContains("public/assets/styles.css", "@import", "Styles should not import third-party design libraries.");
 await rejectContains("src/client.ts", "react", "The frontend should stay framework-free.");
 await rejectContains("src/client.ts", "innerHTML", "Markdown rendering should use DOM nodes instead of HTML injection.");
@@ -34,6 +38,13 @@ async function requireContains(path: string, needle: string, message: string): P
 async function rejectContains(path: string, needle: string, message: string): Promise<void> {
   const text = await readFile(join(root, path), "utf8");
   if (text.includes(needle)) {
+    failures.push(`${path}: ${message}`);
+  }
+}
+
+async function rejectPattern(path: string, pattern: RegExp, message: string): Promise<void> {
+  const text = await readFile(join(root, path), "utf8");
+  if (pattern.test(text)) {
     failures.push(`${path}: ${message}`);
   }
 }


### PR DESCRIPTION
**Do not merge before morning review.**

Site: ycriticalhistory.org. Scope per FACTS.md section T ("HSTS missing on all five sites"; "Zero Open Graph tags anywhere").

## Exact changes

1. **HSTS on every response** — `src/server.ts`: all responses now pass through a `withSecurityHeaders` wrapper (same pattern as the medlock server's `src/http.ts`) setting `Strict-Transport-Security: max-age=31536000; includeSubDomains`. Both mapped domains (`ycriticalhistory.org`, `www.ycriticalhistory.org`, per `infra/terraform/prod/main.tf`) already serve valid TLS, so `includeSubDomains` is safe. No `preload`: the platform http→https redirect is an infra-level 302 (see below), which fails preload eligibility, and preload is a long-term commitment to decide deliberately.
2. **Open Graph + Twitter card tags** — `public/index.html`: `og:type`, `og:site_name`, `og:title`, `og:description`, `og:url`, `og:image` (+`width`/`height`/`alt`), `twitter:card` (`summary_large_image`), `twitter:title`, `twitter:description`, `twitter:image`. The image is the pre-existing in-repo `public/icons/og-image.png` (1200x630, the site's own map + logo — already in the site's style, previously referenced nowhere). Descriptions mirror the existing meta description verbatim.
3. **Lint rule narrowed, not bypassed** — `tools/lint.ts`: the blanket `rejectContains(index.html, "https://")` check blocked the spec-required absolute `og:url`/`og:image` values. Replaced with a regex that rejects `https?://` only inside `<script src>` / `<link href>`, preserving the rule's intent. Negative-tested: injecting a third-party `<script src="https://...">` or `<link href="https://...">` still fails lint.
4. **Test added** — `test/server.test.ts`: asserts the HSTS header on API, static, app-shell, and 404 responses.

## Explicitly not changed

- **Meta description**: already present in `public/index.html` (FACTS T lists it missing only on cdbentley + runsetta). Unchanged.
- **Favicon**: the 404 is runsetta's; here `/favicon.ico` returns 200 live and locally (server maps it to `icons/favicon.ico`).
- **http→https redirect (302 vs 301)**: checked where the redirect actually happens before coding. It is infra-level, not app-level — the app never sees http traffic:

```
$ curl -sI http://ycriticalhistory.org/
HTTP/1.1 302 Found
location: https://ycriticalhistory.org/
server: Google Frontend
```

`server: Google Frontend` + `x-cloud-trace-context` = the redirect is issued by Cloud Run's Google Frontend before reaching the Bun server. Changing 302→301 is a platform behavior (GFE's domain-mapping redirect), not something this repo's code can express; coding a redirect handler here would be dead code. Documented instead, per work-order instruction. If 301 matters later, it needs an infra-level change (e.g., a load balancer in front), which is out of scope tonight.

## Verification

`bun run verify` green (format:check, lint, typecheck, `10 pass 0 fail`, build).

Local server (`bun run build && PORT=4173 bun dist/server.js`):

```
$ curl -sI http://localhost:4173/
HTTP/1.1 200 OK
Cache-Control: no-cache
Content-Type: text/html; charset=utf-8
X-Content-Type-Options: nosniff
Strict-Transport-Security: max-age=31536000; includeSubDomains

$ for p in /api/locations /healthz /privacy /nope.png; do curl -sI http://localhost:4173$p | grep -i strict; done
Strict-Transport-Security: max-age=31536000; includeSubDomains   (x4, incl. the 404)

$ curl -s http://localhost:4173/ | grep -c -E 'og:|twitter:'
13 tags served

$ curl -s -o /dev/null -w "%{http_code} %{content_type}" http://localhost:4173/icons/og-image.png
200 image/png
```

## Secret scans (required gate)

trufflehog 3.95.8: 0 verified + 0 unverified. Org-ref/token-shape grep over tree + full history: 0 matches. gitleaks 8.30.1: 2 findings, **flagged, not scrubbed** — both are the same Mapbox *public* (`pk.`) token hardcoded in 2020-era Hugo files, history-only (commits `8d276e95`, `604037f3`), absent from HEAD; current code reads the token from env. Full triage: `overnight-20260707/ws-b-scans/reports/critical-history-sitefix.md`. Morning action for Collin: confirm that 2020 token is rotated or URL-restricted in the Mapbox dashboard.

FACTS refs: T (HSTS/OG/meta/favicon/redirect current-state), F10 (four production apps incl. ycriticalhistory.org), F9 (site identity — ycriticalhistory.org, never criticalhistory.org).

🤖 Generated with [Claude Code](https://claude.com/claude-code)