### PR TITLE
Adopt Bun 1.4 (platform v0.2.0)

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   verify:
     name: Bun verify
-    uses: collinbentley1/platform/.github/workflows/application.yml@v0.1.2
+    uses: collinbentley1/platform/.github/workflows/application.yml@v0.2.0
     with:
-      bun-version: canary
+      bun-version: 1.4.0
       verify-command: bun run verify

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   cleanup:
-    uses: collinbentley1/platform/.github/workflows/cleanup-preview.yml@v0.1.2
+    uses: collinbentley1/platform/.github/workflows/cleanup-preview.yml@v0.2.0
     with:
       project-id: critical-history-16823277
       region: us-east4

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   deploy:
-    uses: collinbentley1/platform/.github/workflows/deploy-preview.yml@v0.1.2
+    uses: collinbentley1/platform/.github/workflows/deploy-preview.yml@v0.2.0
     with:
       project-id: critical-history-16823277
       region: us-east4

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   deploy:
-    uses: collinbentley1/platform/.github/workflows/deploy-prod.yml@v0.1.2
+    uses: collinbentley1/platform/.github/workflows/deploy-prod.yml@v0.2.0
     with:
       project-id: critical-history-16823277
       region: us-east4

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   infrastructure:
-    uses: collinbentley1/platform/.github/workflows/infrastructure.yml@v0.1.2
+    uses: collinbentley1/platform/.github/workflows/infrastructure.yml@v0.2.0
     with:
       project-id: critical-history-16823277
       workload-identity-provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/socket-firewall.yml
+++ b/.github/workflows/socket-firewall.yml
@@ -13,6 +13,6 @@ permissions:
 jobs:
   firewall:
     name: Socket Firewall
-    uses: collinbentley1/platform/.github/workflows/socket-firewall.yml@v0.1.2
+    uses: collinbentley1/platform/.github/workflows/socket-firewall.yml@v0.2.0
     with:
-      bun-version: canary
+      bun-version: 1.4.0

--- a/.platform/config.json
+++ b/.platform/config.json
@@ -4,6 +4,6 @@
   "region": "us-east4",
   "serviceName": "critical-history",
   "artifactRegistryRepository": "site",
-  "platformVersion": "v0.1.2",
+  "platformVersion": "v0.2.0",
   "runtimeConfigScript": ".github/platform/runtime-config.sh"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,10 @@ FROM dhi.io/bun:1-dev@sha256:67209598b7e7db266ae5630f9b27662d3a80b0915615bbcb9f7
 WORKDIR /app
 
 RUN apt-get update \
-  && apt-get install --no-install-recommends --yes unzip \
+  && apt-get install --no-install-recommends --yes curl unzip \
   && rm -rf /var/lib/apt/lists/* \
-  && bun upgrade --canary
+  && curl -fsSL https://bun.com/install | BUN_INSTALL=/usr/local bash -s "bun-v1.4.0"
+RUN bun -e 'if (Bun.version !== "1.4.0") throw new Error("Bun 1.4 native image requires Bun 1.4.0, got " + Bun.version)'
 
 COPY package.json bun.lock bunfig.toml tsconfig.json ./
 RUN bun ci
@@ -27,6 +28,7 @@ ENV PORT=8080
 ENV PUBLIC_DIR=/app/dist/public
 
 COPY --from=deps /usr/local/bin/bun /usr/local/bin/bun
+RUN ["bun", "-e", "if (Bun.version !== \"1.4.0\") throw new Error(\"Bun 1.4 native image requires Bun 1.4.0, got \" + Bun.version)"]
 COPY --from=build /app/dist ./dist
 
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ The project is now a pure Bun application deployed to Google Cloud Run through G
 
 ## Local Development
 
-Use Bun canary, matching CI and the production Docker build:
+Use stable Bun 1.4, matching CI and the production Docker build (the Docker image pins `bun-v1.4.0` exactly):
 
 ```sh
-bun upgrade --canary
+bun upgrade --stable
 bun install
 cp .env.example .env.local
 bun run dev

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.2.0",
   "private": true,
   "type": "module",
-  "packageManager": "bun@1.4.0-canary.1",
+  "packageManager": "bun@1.4.0",
   "engines": {
-    "bun": ">=1.4.0-canary.1"
+    "bun": ">=1.4.0"
   },
   "scripts": {
     "dev": "bun run build && bun --watch src/server.ts",
@@ -18,7 +18,7 @@
     "format:check": "bun run tools/format.ts --check",
     "hooks:install": "git config core.hooksPath .githooks",
     "verify": "bun ci && bun run format:check && bun run lint && bun test && bun run build",
-    "verify:ci": "bun run format:check && bun run lint && bun test && bun run build"
+    "verify:ci": "bun run --parallel format:check lint test build"
   },
   "dependencies": {
     "mapbox-gl": "3.24.0"

--- a/tools/lint.ts
+++ b/tools/lint.ts
@@ -6,7 +6,7 @@ const root = join(import.meta.dir, "..");
 const failures: string[] = [];
 
 await requireContains("Dockerfile", "dhi.io/bun", "Dockerfile must use Docker Hardened Bun images.");
-await requireContains("Dockerfile", "bun upgrade --canary", "Dockerfile must upgrade Bun to the latest canary.");
+await requireContains("Dockerfile", "bun-v1.4.0", "Dockerfile must pin Bun 1.4.0.");
 await requireContains("public/index.html", 'rel="icon"', "The document must link a favicon.");
 await rejectContains("public/index.html", "https://", "The document should not load third-party scripts or styles.");
 await rejectContains("public/assets/styles.css", "@import", "Styles should not import third-party design libraries.");


### PR DESCRIPTION
## What changed

- Platform workflow pins bumped from `@v0.1.2` to `@v0.2.0` in all six `.github/workflows/*.yml`, and `.platform/config.json` `platformVersion` updated to match.
- `bun-version: canary` replaced with `bun-version: 1.4.0` in `application.yml` and `socket-firewall.yml`.
- `package.json` now declares `packageManager: bun@1.4.0` and `engines.bun: >=1.4.0` (`@types/bun` left at 1.3.14 — no 1.4.x types release exists on npm yet).
- Dockerfile deps stage installs stable Bun via the official installer pinned to exactly `bun-v1.4.0` (replacing `bun upgrade --canary`), followed by a guard that fails the build if `Bun.version !== "1.4.0"`. The runtime stage gets the same guard in exec form right after the bun binary is copied in, since the hardened runtime image has no shell.
- `tools/lint.ts` now enforces the stable pin (`bun-v1.4.0`) instead of requiring the canary upgrade; the dhi.io hardened-image requirement is unchanged.
- README Local Development rewritten for stable Bun 1.4 (`bun upgrade --stable`), noting the image pins `bun-v1.4.0` exactly.
- `verify:ci` converted to the platform template's `bun run --parallel` form. Verified independence first: tests import only from `src/`, `tools/lint.ts` and `tools/format.ts` read only source files, and nothing outside `tools/build.ts` touches `dist/`.

## Why

Bun 1.4 released today and ships everything this app previously needed canary builds for, so the whole toolchain (CI, Docker image, local dev, lint enforcement) moves to the stable pin in one atomic change — required because the lint check self-enforces the Dockerfile's Bun setup.

## Validation

- `bun run verify` green end to end under stable Bun 1.4.0 (bun ci, format:check, lint, typecheck, 9/9 tests, build).
- `bun run tools/verify-socket-config.ts` passes.
- `bun ci` reports no lockfile changes (bun.lock untouched).
- The preview deploy on this PR is the end-to-end validation of the new Docker image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)