### PR TITLE
Adopt platform v0.4.0: health path fix, WIF cleanup pin

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   verify:
     name: Bun verify
-    uses: collinbentley1/platform/.github/workflows/application.yml@v0.3.1
+    uses: collinbentley1/platform/.github/workflows/application.yml@v0.4.0
     with:
       bun-version: 1.4.0
       verify-command: bun run verify

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   cleanup:
-    uses: collinbentley1/platform/.github/workflows/cleanup-preview.yml@v0.3.1
+    uses: collinbentley1/platform/.github/workflows/cleanup-preview.yml@v0.4.0
     with:
       project-id: critical-history-16823277
       region: us-east4

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   deploy:
-    uses: collinbentley1/platform/.github/workflows/deploy-preview.yml@v0.3.1
+    uses: collinbentley1/platform/.github/workflows/deploy-preview.yml@v0.4.0
     with:
       project-id: critical-history-16823277
       region: us-east4

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   deploy:
-    uses: collinbentley1/platform/.github/workflows/deploy-prod.yml@v0.3.1
+    uses: collinbentley1/platform/.github/workflows/deploy-prod.yml@v0.4.0
     with:
       project-id: critical-history-16823277
       region: us-east4

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   infrastructure:
-    uses: collinbentley1/platform/.github/workflows/infrastructure.yml@v0.3.1
+    uses: collinbentley1/platform/.github/workflows/infrastructure.yml@v0.4.0
     with:
       project-id: critical-history-16823277
       workload-identity-provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/socket-firewall.yml
+++ b/.github/workflows/socket-firewall.yml
@@ -13,6 +13,6 @@ permissions:
 jobs:
   firewall:
     name: Socket Firewall
-    uses: collinbentley1/platform/.github/workflows/socket-firewall.yml@v0.3.1
+    uses: collinbentley1/platform/.github/workflows/socket-firewall.yml@v0.4.0
     with:
       bun-version: 1.4.0

--- a/infra/terraform/bootstrap/main.tf
+++ b/infra/terraform/bootstrap/main.tf
@@ -1,5 +1,5 @@
 module "bootstrap" {
-  source = "github.com/collinbentley1/platform//terraform/modules/bootstrap?ref=v0.3.1"
+  source = "github.com/collinbentley1/platform//terraform/modules/bootstrap?ref=v0.4.0"
 
   app                   = "critical-history"
   project_id            = var.project_id

--- a/infra/terraform/prod/main.tf
+++ b/infra/terraform/prod/main.tf
@@ -1,5 +1,5 @@
 module "site" {
-  source = "github.com/collinbentley1/platform//terraform/modules/cloud-run-service?ref=v0.3.1"
+  source = "github.com/collinbentley1/platform//terraform/modules/cloud-run-service?ref=v0.4.0"
 
   providers = {
     google                = google

--- a/src/server.ts
+++ b/src/server.ts
@@ -39,7 +39,7 @@ async function routeRequest(request: Request): Promise<Response> {
     });
   }
 
-  if (url.pathname === "/healthz") {
+  if (url.pathname === "/livez") {
     return json({ ok: true }, { "Cache-Control": "no-store" });
   }
 

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -3,7 +3,7 @@ import { handleRequest } from "../src/server";
 
 describe("server", () => {
   test("returns health status without caching", async () => {
-    const response = await handleRequest(new Request("http://localhost/healthz"));
+    const response = await handleRequest(new Request("http://localhost/livez"));
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Cache-Control")).toBe("no-store");
@@ -45,7 +45,7 @@ describe("server", () => {
   });
 
   test("sets strict-transport-security on every response", async () => {
-    const paths = ["/healthz", "/api/config", "/api/locations", "/", "/privacy", "/does-not-exist.png"];
+    const paths = ["/livez", "/api/config", "/api/locations", "/", "/privacy", "/does-not-exist.png"];
 
     for (const path of paths) {
       const response = await handleRequest(new Request(`http://localhost${path}`));


### PR DESCRIPTION
## Summary

Adopts the shared platform **v0.4.0** and fixes the app health endpoint so it is actually reachable in production.

### Changes
- **Health path (the key app fix)** — `src/server.ts` moves the readiness endpoint off the Cloud-Run-reserved `/healthz` path to **`/livez`**. On `/healthz` the Cloud Run edge returns its own 404 before the container is ever reached, so the app's `{ ok: true }` (`Cache-Control: no-store`) health JSON was never served in prod. `/livez` is not reserved, so the endpoint now works. `test/server.test.ts` updated to exercise `/livez`.
- **Terraform module pins** — `infra/terraform/bootstrap/main.tf` and `infra/terraform/prod/main.tf` bumped from `?ref=v0.3.1` to `?ref=v0.4.0`. v0.4.0 removes the old subject-based WIF bindings; the corresponding GCP apply is handled separately by the platform rollout, this PR only bumps the pin.
- **Workflow callers** — all six `.github/workflows/*.yml` reusable-workflow references bumped `@v0.3.1` → `@v0.4.0`.
- **Provider** — unchanged: `google = 7.45.0`, no committed lockfile.

### Validation
`bun run verify` passes end-to-end locally on the stable Bun (1.4.0). Preview and production deploys are the real validation surface:
- Preview: `GET /livez` → 200 with health JSON (fix works); `GET /healthz` → still the Cloud Run edge 404 (expected, path is reserved); `/` and an app route → 200.
- Production (post-merge): same `/livez` 200 health JSON, live for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)