### PR TITLE
Remove redundant platformVersion from .platform/config.json

### DIFF
--- a/.platform/config.json
+++ b/.platform/config.json
@@ -4,6 +4,5 @@
   "region": "us-east4",
   "serviceName": "critical-history",
   "artifactRegistryRepository": "site",
-  "platformVersion": "v0.2.0",
   "runtimeConfigScript": ".github/platform/runtime-config.sh"
 }


### PR DESCRIPTION
platform v0.4.1 makes `platform doctor` derive the pinned platform version from the workflow `@vX.Y.Z` callers and the Terraform `?ref` pins — the real source of truth — so this hand-maintained field is read by nothing and only drifted. Remove it. No runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)