### PR TITLE
Harden Critical History public application boundaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,1 @@
-MAPBOX_ACCESS_TOKEN=
-MAPBOX_STYLE=mapbox://styles/collinbentley1/ckd3kwqqw060a1iqgtjne8xs3?optimize=true
-TYPEFORM_URL=https://cdbentley.typeform.com/to/fgEAT2ps
+MAPBOX_PUBLIC_TOKEN=

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ cp .env.example .env.local
 bun run dev
 ```
 
-Set `MAPBOX_ACCESS_TOKEN` in your shell or `.env.local` if you want the map to load locally.
+Set a URL-restricted, read-only Mapbox `pk.*` token as `MAPBOX_PUBLIC_TOKEN`
+in your shell or `.env.local` if you want the map to load locally. The server
+rejects secret `sk.*` tokens rather than exposing them through `/api/config`.
 
 Run the full local check:
 
@@ -81,7 +83,7 @@ gh variable set GCP_TERRAFORM_SERVICE_ACCOUNT --repo collinbentley1/critical-his
 gh variable set GCP_PROD_DEPLOY_SERVICE_ACCOUNT --repo collinbentley1/critical-history --body "$(terraform -chdir=infra/terraform/bootstrap output -raw prod_deploy_service_account_email)"
 gh variable set GCP_PREVIEW_DEPLOY_SERVICE_ACCOUNT --repo collinbentley1/critical-history --body "$(terraform -chdir=infra/terraform/bootstrap output -raw preview_deploy_service_account_email)"
 gh variable set GCP_RUNTIME_SERVICE_ACCOUNT --repo collinbentley1/critical-history --body "$(terraform -chdir=infra/terraform/bootstrap output -raw runtime_service_account_email)"
-gh secret set MAPBOX_ACCESS_TOKEN --repo collinbentley1/critical-history --body "$MAPBOX_ACCESS_TOKEN"
+gh secret set MAPBOX_PUBLIC_TOKEN --env production --repo collinbentley1/critical-history --body "$MAPBOX_PUBLIC_TOKEN"
 ```
 
 The Dockerfile uses Docker Hardened Images. Add `DHI_USERNAME` and `DHI_ACCESS_TOKEN` as GitHub Actions secrets before enabling deploy workflows.

--- a/bun.lock
+++ b/bun.lock
@@ -5,39 +5,21 @@
     "": {
       "name": "critical-history",
       "dependencies": {
-        "mapbox-gl": "3.24.0",
+        "mapbox-gl": "3.29.0",
       },
       "devDependencies": {
         "@socketsecurity/bun-security-scanner": "1.1.2",
-        "@types/bun": "1.3.14",
+        "@types/bun": "1.4.0",
         "typescript": "7.0.2",
       },
     },
   },
   "packages": {
-    "@mapbox/mapbox-gl-supported": ["@mapbox/mapbox-gl-supported@3.0.0", "", {}, "sha512-2XghOwu16ZwPJLOFVuIOaLbN0iKMn867evzXFyf0P22dqugezfJwLmdanAgU25ITvz1TvOfVP4jsDImlDJzcWg=="],
-
-    "@mapbox/point-geometry": ["@mapbox/point-geometry@1.1.0", "", {}, "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ=="],
-
-    "@mapbox/tiny-sdf": ["@mapbox/tiny-sdf@2.2.0", "", {}, "sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg=="],
-
-    "@mapbox/unitbezier": ["@mapbox/unitbezier@0.0.1", "", {}, "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw=="],
-
-    "@mapbox/vector-tile": ["@mapbox/vector-tile@2.0.5", "", { "dependencies": { "@mapbox/point-geometry": "~1.1.0", "@types/geojson": "^7946.0.16", "pbf": "^4.0.2" } }, "sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw=="],
-
     "@socketsecurity/bun-security-scanner": ["@socketsecurity/bun-security-scanner@1.1.2", "", {}, "sha512-TdsAg6SMolubyZ6HfIjLWlANfHvhV6i7pdWof4OQ33zPEwXJm2ilA755levHMR618MKq22+06Ag8efiVKowxqA=="],
 
-    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
-
-    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
-
-    "@types/geojson-vt": ["@types/geojson-vt@3.2.5", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g=="],
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
     "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
-
-    "@types/pbf": ["@types/pbf@3.0.5", "", {}, "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA=="],
-
-    "@types/supercluster": ["@types/supercluster@7.1.3", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA=="],
 
     "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 
@@ -79,43 +61,9 @@
 
     "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
-    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
-    "cheap-ruler": ["cheap-ruler@4.0.0", "", {}, "sha512-0BJa8f4t141BYKQyn9NSQt1PguFQXMXwZiA5shfoaBYHAb2fFk2RAX+tiWMoQU+Agtzt3mdt0JtuyshAXqZ+Vw=="],
-
-    "csscolorparser": ["csscolorparser@1.0.3", "", {}, "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w=="],
-
-    "earcut": ["earcut@3.0.2", "", {}, "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ=="],
-
-    "geojson-vt": ["geojson-vt@4.0.3", "", {}, "sha512-jR1MwkLaZGa8Zftct9ZFruyWFrdl9ZyD2OliXNy9Qq5bBPeg5wHVpBQF9p5GjnicSDQqvBVpysxTPKmWdsfWMA=="],
-
-    "gl-matrix": ["gl-matrix@3.4.4", "", {}, "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ=="],
-
-    "kdbush": ["kdbush@4.1.0", "", {}, "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ=="],
-
-    "mapbox-gl": ["mapbox-gl@3.24.0", "", { "dependencies": { "@mapbox/mapbox-gl-supported": "^3.0.0", "@mapbox/point-geometry": "^1.1.0", "@mapbox/tiny-sdf": "^2.0.6", "@mapbox/unitbezier": "^0.0.1", "@mapbox/vector-tile": "^2.0.4", "@types/geojson": "^7946.0.16", "@types/geojson-vt": "^3.2.5", "@types/pbf": "^3.0.5", "@types/supercluster": "^7.1.3", "cheap-ruler": "^4.0.0", "csscolorparser": "~1.0.3", "earcut": "^3.0.1", "geojson-vt": "^4.0.2", "gl-matrix": "^3.4.4", "kdbush": "^4.0.2", "martinez-polygon-clipping": "^0.8.1", "murmurhash-js": "^1.0.0", "pbf": "^4.0.1", "potpack": "^2.0.0", "quickselect": "^3.0.0", "supercluster": "^8.0.1", "tinyqueue": "^3.0.0" } }, "sha512-R+FdFUB3DnoE5FYASV7lGSiRyMkSblcZ2UEy7b2pt7s5ZbCxFIUPXd0E6iAFd8OdvdA2VtbvZZVylzAZNaurjA=="],
-
-    "martinez-polygon-clipping": ["martinez-polygon-clipping@0.8.1", "", { "dependencies": { "robust-predicates": "^2.0.4", "splaytree": "^0.1.4", "tinyqueue": "3.0.0" } }, "sha512-9PLLMzMPI6ihHox4Ns6LpVBLpRc7sbhULybZ/wyaY8sY3ECNe2+hxm1hA2/9bEEpRrdpjoeduBuZLg2aq1cSIQ=="],
-
-    "murmurhash-js": ["murmurhash-js@1.0.0", "", {}, "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw=="],
-
-    "pbf": ["pbf@4.0.2", "", { "dependencies": { "resolve-protobuf-schema": "^2.1.0" }, "bin": { "pbf": "bin/pbf" } }, "sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg=="],
-
-    "potpack": ["potpack@2.1.0", "", {}, "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ=="],
-
-    "protocol-buffers-schema": ["protocol-buffers-schema@3.6.1", "", {}, "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ=="],
-
-    "quickselect": ["quickselect@3.0.0", "", {}, "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g=="],
-
-    "resolve-protobuf-schema": ["resolve-protobuf-schema@2.1.0", "", { "dependencies": { "protocol-buffers-schema": "^3.3.1" } }, "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ=="],
-
-    "robust-predicates": ["robust-predicates@2.0.4", "", {}, "sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg=="],
-
-    "splaytree": ["splaytree@0.1.4", "", {}, "sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ=="],
-
-    "supercluster": ["supercluster@8.0.1", "", { "dependencies": { "kdbush": "^4.0.2" } }, "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ=="],
-
-    "tinyqueue": ["tinyqueue@3.0.0", "", {}, "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g=="],
+    "mapbox-gl": ["mapbox-gl@3.29.0", "", {}, "sha512-Fnh1WLsZMfihwRZY5scp456iQuZo9G97tTpb26bf/Ejsi/L7O+4dE9+I03VoOor2ul3DEOp6F2P3273omyVsNw=="],
 
     "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "verify:ci": "bun run --parallel format:check lint test build"
   },
   "dependencies": {
-    "mapbox-gl": "3.24.0"
+    "mapbox-gl": "3.29.0"
   },
   "devDependencies": {
     "@socketsecurity/bun-security-scanner": "1.1.2",
-    "@types/bun": "1.3.14",
+    "@types/bun": "1.4.0",
     "typescript": "7.0.2"
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -306,8 +306,8 @@ async function setupMap(config: AppConfig): Promise<void> {
     for (const location of appLocations) {
       addMarker(location);
     }
-  } catch (error) {
-    console.error(error);
+  } catch {
+    console.error("map setup failed");
     showMapStatus("Map unavailable.");
   }
 }

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -11,7 +11,7 @@ export function splitMarkdownBlocks(markdown: string): string[] {
 export function isSafeExternalHref(href: string): boolean {
   try {
     const url = new URL(href, "https://critical-history.local");
-    return url.protocol === "http:" || url.protocol === "https:" || url.protocol === "mailto:";
+    return url.protocol === "https:" || url.protocol === "mailto:";
   } catch {
     return false;
   }
@@ -87,7 +87,7 @@ function renderLink(label: string, href: string): Node {
   anchor.href = href;
   anchor.textContent = label;
 
-  if (anchor.protocol === "http:" || anchor.protocol === "https:") {
+  if (anchor.protocol === "https:") {
     anchor.rel = "noopener noreferrer";
     anchor.target = "_blank";
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,4 @@
+import { realpath, stat } from "node:fs/promises";
 import { extname, resolve, sep } from "node:path";
 import { locations } from "./locations";
 
@@ -6,9 +7,19 @@ const IS_BUILT_SERVER = import.meta.dir.endsWith("/dist");
 const BUILT_PUBLIC_DIR = resolve(import.meta.dir, "public");
 const SOURCE_PUBLIC_DIR = resolve(import.meta.dir, "..", "public");
 const PUBLIC_DIR = resolve(Bun.env.PUBLIC_DIR ?? (IS_BUILT_SERVER ? BUILT_PUBLIC_DIR : SOURCE_PUBLIC_DIR));
+const DEFAULT_MAP_STYLE = "mapbox://styles/collinbentley1/ckd3kwqqw060a1iqgtjne8xs3?optimize=true";
+const DEFAULT_TYPEFORM_URL = "https://cdbentley.typeform.com/to/fgEAT2ps";
 
 const SECURITY_HEADERS: Readonly<Record<string, string>> = {
+  "Content-Security-Policy":
+    "default-src 'self'; base-uri 'none'; child-src blob:; connect-src 'self' https://api.mapbox.com https://events.mapbox.com; font-src 'self' data:; form-action 'none'; frame-ancestors 'none'; img-src 'self' data: blob:; object-src 'none'; script-src 'self'; style-src 'self'; worker-src 'self' blob:",
+  "Cross-Origin-Opener-Policy": "same-origin",
+  "Cross-Origin-Resource-Policy": "same-origin",
+  "Permissions-Policy": "camera=(), geolocation=(), microphone=(), payment=()",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
   "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+  "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
 };
 
 const CONTENT_TYPES: Readonly<Record<string, string>> = {
@@ -26,7 +37,15 @@ const CONTENT_TYPES: Readonly<Record<string, string>> = {
 };
 
 export async function handleRequest(request: Request): Promise<Response> {
-  return withSecurityHeaders(await routeRequest(request));
+  try {
+    const response = withSecurityHeaders(await routeRequest(request));
+    return request.method === "HEAD"
+      ? new Response(null, { headers: response.headers, status: response.status, statusText: response.statusText })
+      : response;
+  } catch (error) {
+    console.error("request failed", error instanceof Error ? error.name : "unknown error");
+    return withSecurityHeaders(new Response("internal server error", { status: 500 }));
+  }
 }
 
 async function routeRequest(request: Request): Promise<Response> {
@@ -46,9 +65,9 @@ async function routeRequest(request: Request): Promise<Response> {
   if (url.pathname === "/api/config") {
     return json(
       {
-        mapStyle: Bun.env.MAPBOX_STYLE ?? "mapbox://styles/collinbentley1/ckd3kwqqw060a1iqgtjne8xs3?optimize=true",
-        mapboxAccessToken: Bun.env.MAPBOX_ACCESS_TOKEN ?? "",
-        typeformUrl: Bun.env.TYPEFORM_URL ?? "https://cdbentley.typeform.com/to/fgEAT2ps",
+        mapStyle: DEFAULT_MAP_STYLE,
+        mapboxAccessToken: readPublicMapboxToken(Bun.env.MAPBOX_PUBLIC_TOKEN),
+        typeformUrl: DEFAULT_TYPEFORM_URL,
       },
       { "Cache-Control": "no-store" },
     );
@@ -59,13 +78,19 @@ async function routeRequest(request: Request): Promise<Response> {
   }
 
   const response = await serveStatic(url.pathname);
-  return request.method === "HEAD" ? new Response(null, { headers: response.headers, status: response.status, statusText: response.statusText }) : response;
+  return response;
 }
 
 if (import.meta.main) {
   const server = Bun.serve({
+    development: false,
+    error(error) {
+      console.error("server error", error instanceof Error ? error.name : "unknown error");
+      return withSecurityHeaders(new Response("internal server error", { status: 500 }));
+    },
     fetch: handleRequest,
     hostname: "0.0.0.0",
+    maxRequestBodySize: 1_024,
     port: PORT,
   });
 
@@ -101,36 +126,45 @@ async function serveStatic(pathname: string): Promise<Response> {
     return new Response("not found", { status: 404 });
   }
 
-  let file = Bun.file(filePath);
-  let pathForType = file.name ?? filePath;
+  let fileResult = await resolveExistingFile(PUBLIC_DIR, filePath);
 
-  if (!(await file.exists()) && !IS_BUILT_SERVER && PUBLIC_DIR === SOURCE_PUBLIC_DIR) {
+  if (!fileResult && !IS_BUILT_SERVER && PUBLIC_DIR === SOURCE_PUBLIC_DIR) {
     const builtFilePath = resolveStaticPath(BUILT_PUBLIC_DIR, pathname);
     if (builtFilePath) {
-      const builtFile = Bun.file(builtFilePath);
-      if (await builtFile.exists()) {
-        file = builtFile;
-        pathForType = builtFile.name ?? builtFilePath;
-      }
+      fileResult = await resolveExistingFile(BUILT_PUBLIC_DIR, builtFilePath);
     }
   }
 
-  if (!(await file.exists()) && shouldServeAppShell(pathname)) {
-    file = Bun.file(resolve(PUBLIC_DIR, "index.html"));
-    pathForType = file.name ?? resolve(PUBLIC_DIR, "index.html");
+  if (!fileResult && shouldServeAppShell(pathname)) {
+    fileResult = await resolveExistingFile(PUBLIC_DIR, resolve(PUBLIC_DIR, "index.html"));
   }
 
-  if (!(await file.exists())) {
+  if (!fileResult) {
     return new Response("not found", { status: 404 });
   }
 
-  return new Response(file, {
+  return new Response(fileResult.file, {
     headers: {
-      "Cache-Control": cacheControl(pathForType),
-      "Content-Type": CONTENT_TYPES[extname(pathForType)] ?? "application/octet-stream",
-      "X-Content-Type-Options": "nosniff",
+      "Cache-Control": cacheControl(fileResult.path),
+      "Content-Type": CONTENT_TYPES[extname(fileResult.path)] ?? "application/octet-stream",
     },
   });
+}
+
+async function resolveExistingFile(publicDir: string, filePath: string): Promise<{ file: ReturnType<typeof Bun.file>; path: string } | undefined> {
+  try {
+    const [canonicalRoot, canonicalPath] = await Promise.all([realpath(publicDir), realpath(filePath)]);
+    if (
+      (canonicalPath !== canonicalRoot && !canonicalPath.startsWith(`${canonicalRoot}${sep}`)) ||
+      !(await stat(canonicalPath)).isFile()
+    ) {
+      return undefined;
+    }
+
+    return { file: Bun.file(canonicalPath), path: canonicalPath };
+  } catch {
+    return undefined;
+  }
 }
 
 function resolveStaticPath(publicDir: string, pathname: string): string | null {
@@ -138,6 +172,10 @@ function resolveStaticPath(publicDir: string, pathname: string): string | null {
   try {
     decodedPathname = decodeURIComponent(pathname);
   } catch {
+    return null;
+  }
+
+  if (decodedPathname.length > 2_048 || /[\u0000-\u001F\u007F]/.test(decodedPathname)) {
     return null;
   }
 
@@ -158,4 +196,17 @@ function shouldServeAppShell(pathname: string): boolean {
 
 function cacheControl(path: string): string {
   return path.endsWith(".css") || path.endsWith(".html") || path.endsWith(".js") ? "no-cache" : "public, max-age=300";
+}
+
+function readPublicMapboxToken(value: string | undefined): string {
+  const token = value?.trim() ?? "";
+  if (!token) {
+    return "";
+  }
+
+  if (!/^pk\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(token)) {
+    throw new Error("MAPBOX_PUBLIC_TOKEN must be a public pk token.");
+  }
+
+  return token;
 }

--- a/test/markdown.test.ts
+++ b/test/markdown.test.ts
@@ -8,7 +8,7 @@ describe("markdown helpers", () => {
 
   test("allows normal outbound links and rejects script URLs", () => {
     expect(isSafeExternalHref("https://example.com")).toBe(true);
-    expect(isSafeExternalHref("http://example.com")).toBe(true);
+    expect(isSafeExternalHref("http://example.com")).toBe(false);
     expect(isSafeExternalHref("mailto:test@example.com")).toBe(true);
     expect(isSafeExternalHref("javascript:alert(1)")).toBe(false);
     expect(isSafeExternalHref("data:text/html,hello")).toBe(false);

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -21,6 +21,25 @@ describe("server", () => {
     expect(body.typeformUrl).toContain("typeform.com");
   });
 
+  test("serves only public Mapbox tokens with fixed approved URLs", async () => {
+    const previousToken = Bun.env.MAPBOX_PUBLIC_TOKEN;
+    const publicToken = `${["p", "k"].join("")}.${"a".repeat(24)}.${"b".repeat(24)}`;
+
+    try {
+      Bun.env.MAPBOX_PUBLIC_TOKEN = publicToken;
+      const configured = await handleRequest(new Request("http://localhost/api/config"));
+      expect(configured.status).toBe(200);
+      expect((await configured.json()).mapboxAccessToken).toBe(publicToken);
+
+      Bun.env.MAPBOX_PUBLIC_TOKEN = `${["s", "k"].join("")}.${"a".repeat(24)}.${"b".repeat(24)}`;
+      const secretToken = await handleRequest(new Request("http://localhost/api/config"));
+      expect(secretToken.status).toBe(500);
+      expect(await secretToken.text()).toBe("internal server error");
+    } finally {
+      restoreEnv("MAPBOX_PUBLIC_TOKEN", previousToken);
+    }
+  });
+
   test("returns sorted location content", async () => {
     const response = await handleRequest(new Request("http://localhost/api/locations"));
     const body = (await response.json()) as Array<{ id: number; title: string }>;
@@ -37,6 +56,17 @@ describe("server", () => {
     expect(response.status).toBe(404);
   });
 
+  test("rejects control characters and unsupported methods without throwing", async () => {
+    const controlPath = await handleRequest(new Request("http://localhost/%00"));
+    const unsupportedMethod = await handleRequest(new Request("http://localhost/", { method: "POST" }));
+
+    expect(controlPath.status).toBe(404);
+    expect(controlPath.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(unsupportedMethod.status).toBe(405);
+    expect(unsupportedMethod.headers.get("Allow")).toBe("GET, HEAD");
+    expect(await unsupportedMethod.text()).toBe("method not allowed");
+  });
+
   test("serves app shell for app routes", async () => {
     const response = await handleRequest(new Request("http://localhost/privacy"));
 
@@ -50,6 +80,26 @@ describe("server", () => {
     for (const path of paths) {
       const response = await handleRequest(new Request(`http://localhost${path}`));
       expect(response.headers.get("Strict-Transport-Security")).toBe("max-age=31536000; includeSubDomains");
+      expect(response.headers.get("Content-Security-Policy")).toContain("connect-src 'self' https://api.mapbox.com");
+      expect(response.headers.get("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
+      expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+      expect(response.headers.get("X-Frame-Options")).toBe("DENY");
     }
   });
+
+  test("strips response bodies from API HEAD requests", async () => {
+    const response = await handleRequest(new Request("http://localhost/api/locations", { method: "HEAD" }));
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("");
+    expect(response.headers.get("Content-Type")).toContain("application/json");
+  });
 });
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete Bun.env[key];
+  } else {
+    Bun.env[key] = value;
+  }
+}

--- a/tools/build.ts
+++ b/tools/build.ts
@@ -20,7 +20,6 @@ const clientBuild = await Bun.build({
   naming: "assets/client.js",
   outdir: distPublicDir,
   splitting: true,
-  sourcemap: "external",
   target: "browser",
 });
 
@@ -31,7 +30,6 @@ const serverBuild = await Bun.build({
   external: ["*.html", "*.css", "*.jpg", "*.md", "*.png", "*.svg", "*.webmanifest", "*.xml"],
   minify: false,
   outdir: distDir,
-  sourcemap: "external",
   target: "bun",
 });
 

--- a/tools/lint.ts
+++ b/tools/lint.ts
@@ -16,6 +16,12 @@ await rejectPattern(
 await rejectContains("public/assets/styles.css", "@import", "Styles should not import third-party design libraries.");
 await rejectContains("src/client.ts", "react", "The frontend should stay framework-free.");
 await rejectContains("src/client.ts", "innerHTML", "Markdown rendering should use DOM nodes instead of HTML injection.");
+await rejectContains("src/server.ts", "MAPBOX_ACCESS_TOKEN", "The app must never expose a secret-capable Mapbox token variable.");
+await requireContains("src/server.ts", "MAPBOX_PUBLIC_TOKEN", "The app must use a validated public Mapbox token variable.");
+await rejectContains("src/server.ts", "Bun.env.MAPBOX_STYLE", "The approved Mapbox style must not drift through runtime configuration.");
+await rejectContains("src/server.ts", "Bun.env.TYPEFORM_URL", "The approved Typeform URL must not drift through runtime configuration.");
+await requireContains("src/server.ts", "Content-Security-Policy", "Every response must carry a Content Security Policy.");
+await rejectContains("tools/build.ts", "sourcemap", "Production builds must not publish source maps or embedded sources.");
 
 for (const locationError of validateLocationSet(locations)) {
   failures.push(`src/locations: ${locationError}`);


### PR DESCRIPTION
## Finding

An unauthenticated caller could send unsupported or oversized requests, malformed/control-character paths, and traversal/symlink probes to the public Bun server. Static path checks were lexical only, production responses lacked a complete browser-security policy, and production source maps published original client/server sources. Runtime configuration also accepted a secret-capable Mapbox variable plus mutable style/Typeform URLs.

Impact ranged from availability/log amplification and unintended file exposure if a symlink appeared under the public tree, to browser-side weakening and accidental publication of a Mapbox secret token.

## Fix

- Restrict the public server to GET/HEAD and cap request bodies at 1 KiB.
- Reject malformed, control-character, overlong, traversal, and canonical-path escapes; serve regular files only.
- Return generic hardened errors with `development: false`.
- Add CSP, COOP/CORP, nosniff, frame, referrer, permissions, and HSTS headers on every response.
- Remove production source maps and add regression-policy checks.
- Accept only a `pk.*` `MAPBOX_PUBLIC_TOKEN`; reject secret `sk.*` tokens.
- Fix the Mapbox style and Typeform URL in reviewed source rather than mutable runtime configuration.
- Permit only HTTPS/mailto markdown links and avoid logging client exception details.
- Update Mapbox GL and Bun types to current reviewed versions.

## Validation

- `bun run verify`: 13 tests, 68 assertions; format, lint, typecheck, tests, and build all pass.
- `bun audit` and `bun audit --production`: zero findings.
- `bun outdated`: no outdated packages.
- `git diff --check`: clean.
- Redacted current-tree/history secret scan: current tree clean; two historical public `pk.*` Mapbox-token findings remain and require provider-side rotation/restriction.
- Local browser exercise: page rendered under the strict CSP, external CSS/scripts loaded, 10 canvases initialized, and map interaction worked with a public token.
- Adversarial path/control/overlong/symlink, method, HEAD, header, markdown-protocol, and token-classification regressions pass.

## Rollout gate

Do **not** merge/deploy this PR alone. The live callers still use mutable `platform@v0.4.0` and the legacy runtime helper, which emits the old Mapbox variable. Merge only after the hardened platform exact-SHA caller cutover and after distinct protected `preview-cloud` and `production` environment values are installed. GitHub Actions remains intentionally disabled, so no preview or production validation is claimed yet.